### PR TITLE
fix: improve null safety in ReadySystem, MatchManager, and MatchUtility

### DIFF
--- a/src/FiveStack.Services/MatchManager.cs
+++ b/src/FiveStack.Services/MatchManager.cs
@@ -83,14 +83,15 @@ public class MatchManager
 
     public MatchMap? GetCurrentMap()
     {
-        if (_matchData == null || _matchData.current_match_map_id == null)
+        var matchData = _matchData;
+        if (matchData == null || matchData.current_match_map_id == null)
         {
             return null;
         }
 
-        return _matchData?.match_maps.FirstOrDefault(match_map =>
+        return matchData.match_maps.FirstOrDefault(match_map =>
         {
-            return match_map.id == _matchData.current_match_map_id;
+            return match_map.id == matchData.current_match_map_id;
         });
     }
 

--- a/src/FiveStack.Services/ReadySystem.cs
+++ b/src/FiveStack.Services/ReadySystem.cs
@@ -233,7 +233,10 @@ public class ReadySystem
             return;
         }
 
-        bool isReady = _readyPlayers[player.UserId.Value];
+        if (!_readyPlayers.TryGetValue(player.UserId.Value, out bool isReady))
+        {
+            return;
+        }
 
         string readyWord = isReady ? _localizer["ready.ready"] : _localizer["ready.not_ready"];
         string colored = isReady

--- a/src/FiveStack.Services/ReadySystem.cs
+++ b/src/FiveStack.Services/ReadySystem.cs
@@ -233,10 +233,7 @@ public class ReadySystem
             return;
         }
 
-        if (!_readyPlayers.TryGetValue(player.UserId.Value, out bool isReady))
-        {
-            return;
-        }
+        _readyPlayers.TryGetValue(player.UserId.Value, out bool isReady);
 
         string readyWord = isReady ? _localizer["ready.ready"] : _localizer["ready.not_ready"];
         string colored = isReady

--- a/src/FiveStack.Utilities/MatchUtility.cs
+++ b/src/FiveStack.Utilities/MatchUtility.cs
@@ -57,7 +57,7 @@ namespace FiveStack.Utilities
                     ? matchData.lineup_1.tag
                     : matchData.lineup_2.tag;
 
-            if (tag == null || tag == "")
+            if (string.IsNullOrEmpty(tag))
             {
                 return null;
             }


### PR DESCRIPTION
## Summary
- **ReadySystem.SendReadyMessage**: Use `TryGetValue` instead of direct dictionary indexer to prevent `KeyNotFoundException` when a player reconnects and isn't yet in `_readyPlayers`
- **MatchManager.GetCurrentMap**: Capture `_matchData` in a local variable before passing to lambda, preventing a race condition if the field becomes null between the null check and lambda execution
- **MatchUtility.GetPlayerLineupTag**: Replace `tag == null || tag == ""` with idiomatic `string.IsNullOrEmpty(tag)`

## Test plan
- [ ] Player reconnecting during ready phase doesn't crash the server
- [ ] Current map lookup works correctly during active matches
- [ ] Player lineup tags display correctly (including empty/null tags)

Closes 5stackgg/5stack-panel#399