### PR TITLE
fix: add proper resource disposal for HttpClient, WebSocket, timers, and pending messages

### DIFF
--- a/src/FiveStack.Services/MatchEvents.cs
+++ b/src/FiveStack.Services/MatchEvents.cs
@@ -206,15 +206,17 @@ public class MatchEvents
             {
                 _logger.LogWarning($"Error closing existing WebSocket: {ex.Message}");
             }
+            _webSocket.Dispose();
             _webSocket = null;
         }
 
         _connectionCts?.Cancel();
         _connectionCts = new CancellationTokenSource();
 
+        ClientWebSocket? newWebSocket = null;
         try
         {
-            _webSocket = new ClientWebSocket();
+            newWebSocket = new ClientWebSocket();
 
             _environmentService.Load();
 
@@ -224,10 +226,11 @@ public class MatchEvents
             if (serverId == null || serverApiPassword == null)
             {
                 _logger.LogWarning("Cannot connect to WebSocket, Missing Server ID / API Password");
+                newWebSocket.Dispose();
                 return false;
             }
 
-            _webSocket.Options.SetRequestHeader(
+            newWebSocket.Options.SetRequestHeader(
                 "Authorization",
                 $"Basic {Convert.ToBase64String(
                 System.Text.Encoding.UTF8.GetBytes($"{serverId}:{serverApiPassword}")
@@ -235,7 +238,9 @@ public class MatchEvents
             );
 
             var uri = new Uri($"{_environmentService.GetWsUrl()}/matches");
-            await _webSocket.ConnectAsync(uri, _connectionCts.Token);
+            await newWebSocket.ConnectAsync(uri, _connectionCts.Token);
+
+            _webSocket = newWebSocket;
 
             _matchService.GetMatchFromApi();
 
@@ -244,11 +249,13 @@ public class MatchEvents
         catch (WebSocketException ex)
         {
             _logger.LogWarning("Failed to connect to WebSocket server: " + ex.Message);
+            newWebSocket?.Dispose();
             return false;
         }
         catch (Exception ex)
         {
             _logger.LogCritical("An error occurred: " + ex.Message);
+            newWebSocket?.Dispose();
             return false;
         }
     }
@@ -259,6 +266,7 @@ public class MatchEvents
         _connectionCts?.Cancel();
         _isMonitoring = false;
         _retryTimer.Stop();
+        _retryTimer?.Dispose();
 
         if (_webSocket != null && _webSocket.State == WebSocketState.Open)
         {
@@ -267,6 +275,7 @@ public class MatchEvents
                 "Disconnecting",
                 CancellationToken.None
             );
+            _webSocket.Dispose();
             _webSocket = null;
         }
     }
@@ -324,6 +333,12 @@ public class MatchEvents
         if (data is EventData<Dictionary<string, object>> typedData)
         {
             _pendingMessages[data.messageId] = (typedData, DateTime.UtcNow);
+
+            if (_pendingMessages.Count > 1000)
+            {
+                var oldest = _pendingMessages.OrderBy(p => p.Value.Timestamp).First();
+                _pendingMessages.Remove(oldest.Key);
+            }
         }
 
         try

--- a/src/FiveStack.Services/MatchService.cs
+++ b/src/FiveStack.Services/MatchService.cs
@@ -79,8 +79,6 @@ public class MatchService
             return;
         }
 
-        HttpClient httpClient = new HttpClient();
-
         string? serverId = _environmentService.GetServerId();
         string? apiPassword = _environmentService.GetServerApiPassword();
 
@@ -97,53 +95,57 @@ public class MatchService
 
         try
         {
-            string matchUri = $"{_environmentService.GetApiUrl()}/matches/current-match/{serverId}";
-
-            _logger.LogInformation($"Fetching Match Info for server : {serverId}");
-
-            httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiPassword);
-
-            string? response = await httpClient.GetStringAsync(matchUri);
-
-            Server.NextFrame(() =>
+            using (var httpClient = new HttpClient())
             {
-                if (response.Length == 0)
+                string matchUri =
+                    $"{_environmentService.GetApiUrl()}/matches/current-match/{serverId}";
+
+                _logger.LogInformation($"Fetching Match Info for server : {serverId}");
+
+                httpClient.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiPassword);
+
+                string? response = await httpClient.GetStringAsync(matchUri);
+
+                Server.NextFrame(() =>
                 {
+                    if (response.Length == 0)
+                    {
+                        if (_currentMatch != null)
+                        {
+                            _currentMatch.Reset();
+                        }
+
+                        _currentMatch = null;
+
+                        _logger.LogWarning("currenlty no match assigned to server");
+                        return;
+                    }
+
+                    MatchData? matchData = JsonSerializer.Deserialize<MatchData>(response);
+
+                    if (matchData == null)
+                    {
+                        return;
+                    }
+
+                    if (_currentMatch?.GetMatchData()?.id == matchData.id)
+                    {
+                        _currentMatch.SetupMatch(matchData);
+                        return;
+                    }
+
                     if (_currentMatch != null)
                     {
                         _currentMatch.Reset();
                     }
 
-                    _currentMatch = null;
+                    _currentMatch =
+                        _serviceProvider.GetRequiredService(typeof(MatchManager)) as MatchManager;
 
-                    _logger.LogWarning("currenlty no match assigned to server");
-                    return;
-                }
-
-                MatchData? matchData = JsonSerializer.Deserialize<MatchData>(response);
-
-                if (matchData == null)
-                {
-                    return;
-                }
-
-                if (_currentMatch?.GetMatchData()?.id == matchData.id)
-                {
-                    _currentMatch.SetupMatch(matchData);
-                    return;
-                }
-
-                if (_currentMatch != null)
-                {
-                    _currentMatch.Reset();
-                }
-
-                _currentMatch =
-                    _serviceProvider.GetRequiredService(typeof(MatchManager)) as MatchManager;
-
-                _currentMatch!.SetupMatch(matchData);
-            });
+                    _currentMatch!.SetupMatch(matchData);
+                });
+            }
         }
         catch (HttpRequestException ex)
         {

--- a/src/FiveStack.Services/SurrenderSystem.cs
+++ b/src/FiveStack.Services/SurrenderSystem.cs
@@ -155,8 +155,8 @@ public class SurrenderSystem
             {
                 timer?.Kill();
             }
-            _disconnectTimers[team].Clear();
         }
+        _disconnectTimers.Clear();
     }
 
     public bool IsSurrendering()


### PR DESCRIPTION
## Summary
- Wrap `HttpClient` in `using` statement in `MatchService.GetMatchFromApi()`
- Dispose `_retryTimer` and `_webSocket` in `MatchEvents.Disconnect()`; dispose old WebSocket in `Connect()` before replacement
- Cap `_pendingMessages` at 1000 entries to prevent unbounded growth
- Clear entire `_disconnectTimers` dictionary in `SurrenderSystem.Reset()`

Closes 5stackgg/5stack-panel#398

## Test plan
- [ ] Verify match data fetching works after HttpClient disposal change
- [ ] Verify WebSocket reconnection works correctly
- [ ] Verify surrender timer cleanup works after Reset()