### PR TITLE
feature: beta release channel builds + beta image retention

### DIFF
--- a/.github/workflows/beta-build.yaml
+++ b/.github/workflows/beta-build.yaml
@@ -1,6 +1,9 @@
 name: Branch Build and Push
 
 on:
+  push:
+    branches:
+      - "beta"
   workflow_dispatch:
     inputs:
       branch_name:
@@ -11,6 +14,9 @@ on:
 jobs:
   branch-build-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -45,18 +51,19 @@ jobs:
 
     - name: Sanitize branch name
       id: sanitize
+      env:
+        BRANCH_NAME: ${{ github.event.inputs.branch_name || github.ref_name }}
       run: |
-        BRANCH_NAME="${{ github.event.inputs.branch_name || github.ref_name }}"
         SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
         echo "sanitized_branch=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
-        
+
     - name: Build and Push Docker image
       uses: docker/build-push-action@v6
       with:
         push: true
         tags: |
             ghcr.io/${{ github.repository_owner }}/game-server:${{ steps.sanitize.outputs.sanitized_branch }}
-            ghcr.io/${{ github.repository_owner }}/game-server:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/game-server:${{ steps.sanitize.outputs.sanitized_branch }}-${{ github.sha }}
         build-args: |
           RELEASE_VERSION=${{ github.sha }}
 
@@ -70,4 +77,36 @@ jobs:
         draft: true
         prerelease: true
         files: |
-          ./FiveStack-${{ github.sha }}.zip 
+          ./FiveStack-${{ github.sha }}.zip
+
+    - name: Prune old beta images
+      if: github.ref_name == 'beta'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const keep = 5;
+          const owner = context.repo.owner;
+          const pkg = 'game-server';
+          const isBeta = (t) => t === 'beta' || t.startsWith('beta-');
+          const { data: ownerInfo } = await github.rest.users.getByUsername({ username: owner });
+          const isOrg = ownerInfo.type === 'Organization';
+          const listFn = isOrg
+            ? github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg
+            : github.rest.packages.getAllPackageVersionsForPackageOwnedByUser;
+          const listArgs = isOrg
+            ? { package_type: 'container', package_name: pkg, org: owner, per_page: 100 }
+            : { package_type: 'container', package_name: pkg, username: owner, per_page: 100 };
+          const versions = await github.paginate(listFn, listArgs);
+          const beta = versions.filter((v) => {
+            const tags = v.metadata?.container?.tags || [];
+            return tags.length > 0 && tags.some(isBeta);
+          });
+          beta.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+          const toDelete = beta.slice(keep);
+          for (const v of toDelete) {
+            await (isOrg
+              ? github.rest.packages.deletePackageVersionForOrg({ package_type: 'container', package_name: pkg, org: owner, package_version_id: v.id })
+              : github.rest.packages.deletePackageVersionForUser({ package_type: 'container', package_name: pkg, username: owner, package_version_id: v.id }));
+            core.info(`deleted ${pkg} ${v.id} [${(v.metadata?.container?.tags || []).join(', ')}]`);
+          }
+          core.info(`beta candidates=${beta.length} deleted=${toDelete.length}`);


### PR DESCRIPTION
Part of the cross-repo beta release channel feature (admins switch channels from the web panel; match pods resolve `game-server:beta` with fallback to `:latest`, and `pin_plugin_version` still takes precedence).

## Changes
- `beta-build.yaml` now also triggers on pushes to the `beta` branch (dispatch with `branch_name` still works)
- SHA images are tagged `beta-<sha>` (prefixed) so the beta channel is a self-contained tag namespace
- Added a beta-scoped prune (keep 5) that only ever deletes `beta`/`beta-*`-tagged versions — `plugin.yaml` main builds and version tags (`v0.0.N`) are never touched
- Branch-name sanitation moved into an env var before shell interpolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)